### PR TITLE
Add macOS Catalina support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Atom package imports the “SF Mono” font directly from `Terminal.app`, w
 
 __Usage:__
 
-1. Get a Mac and install Mac OS X Sierra.
+1. Get a Mac and install Mac OS X Sierra or higher.
 
 2. Install this Atom package.
 
@@ -14,19 +14,4 @@ __Usage:__
 
 4. Gorgeous.
 
-__Note:__ This package does not contain the fonts file. It only references the font files located in your system. Here is the full package code:
-
-```less
-@font-face { font-family: "SF Mono"; font-weight: 200; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Light.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 200; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-LightItalic.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 400; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Regular.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 400; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-RegularItalic.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 500; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Medium.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 500; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-MediumItalic.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 600; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Semibold.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 600; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-SemiboldItalic.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 700; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Bold.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 700; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-BoldItalic.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 800; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Heavy.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 800; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-HeavyItalic.otf); }
-```
+__Note:__ This package does not contain the font files. It only references the font files located in your system. The full package source code is available [here](styles/import-sf-mono.less).

--- a/styles/import-sf-mono.less
+++ b/styles/import-sf-mono.less
@@ -1,12 +1,23 @@
-@font-face { font-family: "SF Mono"; font-weight: 200; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Light.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 200; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-LightItalic.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 400; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Regular.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 400; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-RegularItalic.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 500; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Medium.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 500; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-MediumItalic.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 600; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Semibold.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 600; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-SemiboldItalic.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 700; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Bold.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 700; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-BoldItalic.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 800; font-style: normal; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-Heavy.otf); }
-@font-face { font-family: "SF Mono"; font-weight: 800; font-style: italic; src: url(file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/SFMono-HeavyItalic.otf); }
+.fontFace(@weight, @style, @file) {
+  @font-face {
+    font-family: "SF Mono";
+    font-style: @style;
+    font-weight: @weight;
+    src:
+      url("file:///Applications/Utilities/Terminal.app/Contents/Resources/Fonts/@{file}"),
+      url("file:///System/Applications/Utilities/Terminal.app/Contents/Resources/Fonts/@{file}");
+  }
+}
+
+.fontFace(200, normal, "SFMono-Light.otf");
+.fontFace(200, italic, "SFMono-LightItalic.otf");
+.fontFace(400, normal, "SFMono-Regular.otf");
+.fontFace(400, italic, "SFMono-RegularItalic.otf");
+.fontFace(500, normal, "SFMono-Medium.otf");
+.fontFace(500, italic, "SFMono-MediumItalic.otf");
+.fontFace(600, normal, "SFMono-Semibold.otf");
+.fontFace(600, italic, "SFMono-SemiboldItalic.otf");
+.fontFace(700, normal, "SFMono-Bold.otf");
+.fontFace(700, italic, "SFMono-BoldItalic.otf");
+.fontFace(800, normal, "SFMono-Heavy.otf");
+.fontFace(800, italic, "SFMono-HeavyItalic.otf");


### PR DESCRIPTION
On macOS Catalina font files are in `/System/Applications/Utilities/Terminal.app/Contents/Resources/Fonts`